### PR TITLE
Add gpu metadata

### DIFF
--- a/systematic_debug_report/orchard/logging_.py
+++ b/systematic_debug_report/orchard/logging_.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import csv
+import multiprocessing
 import os
 import socket
 import subprocess
@@ -84,6 +85,29 @@ def setup_logging(cfg: ExperimentConfig) -> Path:
             "slurm_array_job_id": os.environ.get("SLURM_ARRAY_JOB_ID", None),
         },
     }
+    hw: dict[str, Any] = {
+        "cpu_logical_cores": multiprocessing.cpu_count(),
+        "cpu_affinity_cores": len(os.sched_getaffinity(0)),
+    }
+    try:
+        import pynvml
+        pynvml.nvmlInit()
+        handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+        hw["gpu_name"] = pynvml.nvmlDeviceGetName(handle)
+        hw["gpu_vram_mb"] = pynvml.nvmlDeviceGetMemoryInfo(handle).total // 1024**2
+        try:
+            import torch
+            hw["gpu_sm_count"] = torch.cuda.get_device_properties(0).multi_processor_count
+        except Exception:
+            hw["gpu_sm_count"] = None
+        pynvml.nvmlShutdown()
+    except Exception as e:
+        hw["gpu_name"] = None
+        hw["gpu_sm_count"] = None
+        hw["gpu_vram_mb"] = None
+        hw["gpu_pynvml_error"] = str(e)
+    metadata["run"].update(hw)
+
     with open(run_dir / "metadata.yaml", "w") as f:
         yaml.dump(metadata, f, default_flow_style=False, sort_keys=False)
 

--- a/systematic_debug_report/orchard/tests/test_timing.py
+++ b/systematic_debug_report/orchard/tests/test_timing.py
@@ -255,6 +255,7 @@ class TestTimingIntegration:
             assert set(reader.fieldnames) == {
                 "step", "wall_time",
                 "encode_ms", "train_ms", "action_ms", "env_ms", "eval_ms",
+                "total_ms", "sm_util_pct", "vram_allocated_mb", "gpu_mem_util_pct",
             }
             rows = list(reader)
             # 10 total steps / freq 5 = 2 rows

--- a/systematic_debug_report/orchard/train.py
+++ b/systematic_debug_report/orchard/train.py
@@ -102,10 +102,23 @@ def train(cfg: ExperimentConfig, resume_checkpoint: str | None = None, resume_cr
     stopper = EarlyStopper(cfg.train.stopping, cfg.logging.main_csv_freq)
 
     timing_logger = None
+    _nvml_available = False
+    _nvml_handle = None
     if cfg.logging.timing_csv_freq > 0:
+        try:
+            import pynvml
+            pynvml.nvmlInit()
+            _nvml_handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+            _nvml_available = True
+        except Exception as e:
+            print(f"[timing] pynvml unavailable ({e}), sm_util will be -1")
         timing_logger = CSVLogger(
             run_dir / "timing.csv",
-            ["step", "wall_time", "encode_ms", "train_ms", "action_ms", "env_ms", "eval_ms"],
+            ["step", "wall_time",
+             "encode_ms", "train_ms", "action_ms", "env_ms", "eval_ms",
+             "total_ms",
+             "sm_util_pct", "gpu_mem_util_pct",
+             "vram_allocated_mb"],
         )
 
     state = env.init_state()
@@ -197,14 +210,34 @@ def train(cfg: ExperimentConfig, resume_checkpoint: str | None = None, resume_cr
         # ── Timing CSV ──
         if timing_logger is not None and (t + 1) % cfg.logging.timing_csv_freq == 0:
             report = trainer._timer.report_and_reset()
+            encode_ms = round(report[TimerSection.ENCODE] * 1000, 4)
+            train_ms  = round(report[TimerSection.TRAIN]  * 1000, 4)
+            action_ms = round(report[TimerSection.ACTION] * 1000, 4)
+            env_ms    = round(report[TimerSection.ENV]    * 1000, 4)
+            eval_ms   = round(report[TimerSection.EVAL]   * 1000, 4)
+
+            sm_util = gpu_mem_util = -1
+            if _nvml_available:
+                try:
+                    util = pynvml.nvmlDeviceGetUtilizationRates(_nvml_handle)
+                    sm_util      = util.gpu
+                    gpu_mem_util = util.memory
+                except Exception:
+                    pass
+
             timing_logger.log({
-                "step": t + 1,
-                "wall_time": round(time.time() - start_time, 3),
-                "encode_ms": round(report[TimerSection.ENCODE] * 1000, 4),
-                "train_ms": round(report[TimerSection.TRAIN] * 1000, 4),
-                "action_ms": round(report[TimerSection.ACTION] * 1000, 4),
-                "env_ms": round(report[TimerSection.ENV] * 1000, 4),
-                "eval_ms": round(report[TimerSection.EVAL] * 1000, 4),
+                "step":             t + 1,
+                "wall_time":        round(time.time() - start_time, 3),
+                "encode_ms":        encode_ms,
+                "train_ms":         train_ms,
+                "action_ms":        action_ms,
+                "env_ms":           env_ms,
+                "eval_ms":          eval_ms,
+                "total_ms":         round(encode_ms + train_ms + action_ms + env_ms + eval_ms, 4),
+                "sm_util_pct":      sm_util,
+                "gpu_mem_util_pct": gpu_mem_util,
+                "vram_allocated_mb": round(torch.cuda.memory_allocated() / 1024**2, 1)
+                                     if torch.cuda.is_available() else -1,
             })
 
     # --- Finalize ---

--- a/systematic_debug_report/requirements.txt
+++ b/systematic_debug_report/requirements.txt
@@ -6,3 +6,4 @@ pytest==9.0.3
 PyYAML==6.0.3
 scipy==1.17.1
 torch==2.11.0+cu126
+nvidia-ml-py==13.595.45


### PR DESCRIPTION
## Summary
- Restored GPU/CPU hardware metadata logging to `metadata.yaml`
- Added `nvidia-ml-py` to `requirements.txt`

## Changes
- `orchard/logging_.py`: writes `gpu_name`, `gpu_vram_mb`, `gpu_sm_count`, `cpu_logical_cores`, `cpu_affinity_cores` to run metadata
- `orchard/train.py`: initialises pynvml for per-step SM/VRAM utilisation in timing CSV
- `requirements.txt`: added `nvidia-ml-py==13.595.45`

## Test
Ran on `gpunode15` via `srun`, confirmed metadata output:
```yaml
gpu_name: NVIDIA RTX A4500
gpu_vram_mb: 20470
gpu_sm_count: 56
cpu_logical_cores: 4
cpu_affinity_cores: 1
