### PR TITLE
Fix phase2 encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ systematic_debug_report/QUESTIONS.txt
 *.pt
 *.pth
 *.pkl
-
+saved_models/
 # IDE
 .vscode/
 .idea/

--- a/systematic_debug_report/orchard/config.py
+++ b/systematic_debug_report/orchard/config.py
@@ -309,6 +309,7 @@ def _parse_logging(d: dict[str, Any]) -> LoggingConfig:
         main_csv_freq=int(d.get("main_csv_freq", 10000)),
         detail_csv_freq=int(d.get("detail_csv_freq", 50000)),
         timing_csv_freq=int(d.get("timing_csv_freq", 0)),
+        alpha_state_log_freq=int(d.get("alpha_state_log_freq", 0)),
     )
 
 

--- a/systematic_debug_report/orchard/config.py
+++ b/systematic_debug_report/orchard/config.py
@@ -269,6 +269,12 @@ def _parse_train(d: dict[str, Any], n_task_types: int = 1) -> TrainConfig:
     if influencer_cfg.enabled and not following_cfg.enabled:
         raise ValueError("train.influencer.enabled=true requires train.following_rates.enabled=true.")
 
+    warmup_steps = int(d.get("warmup_steps", 0))
+    if warmup_steps < 0:
+        raise ValueError("train.warmup_steps must be >= 0.")
+    if warmup_steps > 0 and algorithm_name != AlgorithmName.ACTOR_CRITIC:
+        raise ValueError("train.warmup_steps>0 requires train.algorithm.name=actor_critic.")
+
     return TrainConfig(
         total_steps=int(d["total_steps"]),
         seed=int(d.get("seed", 42)),
@@ -285,6 +291,7 @@ def _parse_train(d: dict[str, Any], n_task_types: int = 1) -> TrainConfig:
         comm_weight=float(d.get("comm_weight", 0.0)),
         heuristic=heuristic,
         stopping=stopping,
+        warmup_steps=int(d.get("warmup_steps", 0)),
     )
 
 

--- a/systematic_debug_report/orchard/configs/reference.yaml
+++ b/systematic_debug_report/orchard/configs/reference.yaml
@@ -237,6 +237,12 @@ train:
   # Useful when bootstrapping from a pretrained value checkpoint via --resume.
   freeze_critic: false
 
+  # Number of initial steps where critic and actor weight updates are skipped.
+  # Forward passes, alpha/beta updates, and following-rate reallocations still run,
+  # so this lets alpha/beta warm up before touching pretrained weights. Requires
+  # algorithm.name=actor_critic.
+  warmup_steps: 0
+
   # Optional following-rate extension for actor-critic only.
   following_rates:
     enabled: false                 # requires algorithm.name=actor_critic

--- a/systematic_debug_report/orchard/datatypes.py
+++ b/systematic_debug_report/orchard/datatypes.py
@@ -226,6 +226,7 @@ class LoggingConfig:
     main_csv_freq: int = 10000
     detail_csv_freq: int = 50000
     timing_csv_freq: int = 0
+    alpha_state_log_freq: int = 0
 
 
 @dataclass(frozen=True)

--- a/systematic_debug_report/orchard/datatypes.py
+++ b/systematic_debug_report/orchard/datatypes.py
@@ -201,6 +201,7 @@ class TrainConfig:
     comm_weight: float = 0.0
     heuristic: Heuristic = Heuristic.NEAREST_TASK
     stopping: StoppingConfig = StoppingConfig()
+    warmup_steps: int = 0
 
 
 @dataclass(frozen=True)

--- a/systematic_debug_report/orchard/eval.py
+++ b/systematic_debug_report/orchard/eval.py
@@ -14,7 +14,7 @@ from orchard.datatypes import State, Transition
 # ---------------------------------------------------------------------------
 def rollout_trajectory(
     start_state: State,
-    policy_fn: Callable[[State, bool], Action],
+    policy_fn: Callable[[State], Action],
     env: BaseEnv,
     n_steps: int,
 ) -> Iterator[Transition]:
@@ -33,7 +33,7 @@ def rollout_trajectory(
     zero_rewards = tuple(0.0 for _ in range(env.cfg.n_agents))
 
     for _ in range(n_steps):
-        move_action = policy_fn(s, False)
+        move_action = policy_fn(s)
         assert move_action.is_move(), f"Phase 1 must be a move action, got {move_action}"
         s_moved = env.apply_action(s, move_action)
 
@@ -46,7 +46,7 @@ def rollout_trajectory(
                 tau = s_moved.task_type_at(s_moved.agent_positions[s_moved.actor])
                 pick_action = make_pick_action(tau)
             else:
-                pick_action = policy_fn(s_moved.with_pick_phase(), True)
+                pick_action = policy_fn(s_moved.with_pick_phase())
 
             s_picked, pick_rewards = env.resolve_pick(
                 s_moved,
@@ -72,7 +72,7 @@ def rollout_trajectory(
 # ---------------------------------------------------------------------------
 def evaluate_policy_metrics(
     start_state: State,
-    policy_fn: Callable[[State, bool], Action],
+    policy_fn: Callable[[State], Action],
     env: BaseEnv,
     n_steps: int,
 ) -> dict[str, float]:

--- a/systematic_debug_report/orchard/policy.py
+++ b/systematic_debug_report/orchard/policy.py
@@ -36,11 +36,11 @@ def get_phase2_actions(state: State, env_cfg: EnvConfig) -> list[Action]:
 # ---------------------------------------------------------------------------
 # Heuristic policies
 # ---------------------------------------------------------------------------
-def nearest_task_action(state: State, env_cfg: EnvConfig, phase2: bool = False) -> Action:
+def nearest_task_action(state: State, env_cfg: EnvConfig) -> Action:
     """Move actor toward nearest task (Manhattan distance)."""
     actor = state.actor
 
-    if phase2:
+    if state.pick_phase:
         tasks_here = state.tasks_at(state.agent_positions[actor])
         if tasks_here:
             _, tau = tasks_here[0]
@@ -69,7 +69,7 @@ def nearest_task_action(state: State, env_cfg: EnvConfig, phase2: bool = False) 
     return best_action
 
 
-def nearest_correct_task_action(state: State, env_cfg: EnvConfig, phase2: bool = False) -> Action:
+def nearest_correct_task_action(state: State, env_cfg: EnvConfig) -> Action:
     """Move toward nearest correct-type task (τ ∈ G_actor).
 
     Phase 2: always picks whatever task is present (mirrors forced-pick behavior).
@@ -77,7 +77,7 @@ def nearest_correct_task_action(state: State, env_cfg: EnvConfig, phase2: bool =
     actor = state.actor
     good_types = set(env_cfg.task_assignments[actor]) if env_cfg.task_assignments else set()
 
-    if phase2:
+    if state.pick_phase:
         tasks_here = state.tasks_at(state.agent_positions[actor])
         if tasks_here:
             _, tau = tasks_here[0]
@@ -115,31 +115,31 @@ def nearest_correct_task_action(state: State, env_cfg: EnvConfig, phase2: bool =
 
 
 def nearest_correct_task_stay_wrong_action(
-    state: State, env_cfg: EnvConfig, phase2: bool = False,
+    state: State, env_cfg: EnvConfig,
 ) -> Action:
     """Move toward nearest correct-type task; phase 2 picks correct, STAYs on wrong."""
     actor = state.actor
     good_types = set(env_cfg.task_assignments[actor]) if env_cfg.task_assignments else set()
 
-    if phase2:
+    if state.pick_phase:
         tasks_here = state.tasks_at(state.agent_positions[actor])
         for _, tau in tasks_here:
             if tau in good_types:
                 return make_pick_action(tau)
         return Action.STAY
 
-    return nearest_correct_task_action(state, env_cfg, phase2=False)
+    return nearest_correct_task_action(state, env_cfg)
 
 
 def heuristic_action(
-    state: State, env_cfg: EnvConfig, heuristic: Heuristic, phase2: bool = False,
+    state: State, env_cfg: EnvConfig, heuristic: Heuristic,
 ) -> Action:
     """Dispatch to the configured heuristic policy."""
     if heuristic == Heuristic.NEAREST_TASK:
-        return nearest_task_action(state, env_cfg, phase2=phase2)
+        return nearest_task_action(state, env_cfg)
     elif heuristic == Heuristic.NEAREST_CORRECT_TASK:
-        return nearest_correct_task_action(state, env_cfg, phase2=phase2)
+        return nearest_correct_task_action(state, env_cfg)
     elif heuristic == Heuristic.NEAREST_CORRECT_TASK_STAY_WRONG:
-        return nearest_correct_task_stay_wrong_action(state, env_cfg, phase2=phase2)
+        return nearest_correct_task_stay_wrong_action(state, env_cfg)
     else:
         raise ValueError(f"Unknown heuristic: {heuristic}")

--- a/systematic_debug_report/orchard/tests/test_actor_critic_runtime.py
+++ b/systematic_debug_report/orchard/tests/test_actor_critic_runtime.py
@@ -424,9 +424,9 @@ def _install_identity_critic_spy(trainer):
 
 
 def _install_scripted_actions(trainer, *, move_action: Action, pick_action: Action | None = None) -> None:
-    def _sample_action(self, state: State, phase2: bool):
+    def _sample_action(self, state: State):
         actor_state = self._encode_actor_state(state, state.actor)
-        if phase2:
+        if state.pick_phase:
             assert pick_action is not None
             mask = build_phase2_legal_mask(state, self._env.cfg)
             return pick_action, actor_state, np.zeros(mask.shape[0], dtype=float), mask
@@ -443,9 +443,9 @@ def _install_two_actor_choice_cycle_actions(
     actor0_pick: Action,
     actor1_move: Action,
 ) -> None:
-    def _sample_action(self, state: State, phase2: bool):
+    def _sample_action(self, state: State):
         actor_state = self._encode_actor_state(state, state.actor)
-        if phase2:
+        if state.pick_phase:
             mask = build_phase2_legal_mask(state, self._env.cfg)
             return actor0_pick, actor_state, np.zeros(mask.shape[0], dtype=float), mask
         mask = build_phase1_legal_mask(state, self._env.cfg)

--- a/systematic_debug_report/orchard/tests/test_actor_critic_runtime.py
+++ b/systematic_debug_report/orchard/tests/test_actor_critic_runtime.py
@@ -761,6 +761,274 @@ class TestActorCriticTrainingLoop:
         gpu_trainer.step(_make_always_pick_choice_state(), 0)
         assert calls == 2
 
+    def test_warmup_skips_critic_updates(self):
+        _, trainer = _make_actor_critic_trainer(PickMode.CHOICE)
+        trainer._warmup_steps = 5
+        spy = _install_identity_critic_spy(trainer)
+        _install_scripted_actions(
+            trainer,
+            move_action=Action.RIGHT,
+            pick_action=make_pick_action(0),
+        )
+
+        sentinel_after = State(
+            agent_positions=(Grid(2, 0), Grid(2, 2)),
+            task_positions=(),
+            actor=1,
+            task_types=(),
+        )
+        trainer._critic_prev_after = sentinel_after
+
+        state = State(
+            agent_positions=(Grid(0, 0), Grid(2, 2)),
+            task_positions=(Grid(0, 1),),
+            actor=0,
+            task_types=(0,),
+        )
+
+        trainer.step(state, t=0)
+
+        assert spy["td_calls"] == []
+        assert trainer._critic_prev_after is None
+
+    def test_warmup_skips_actor_updates(self):
+        _, trainer = _make_actor_critic_trainer(PickMode.CHOICE)
+        trainer._warmup_steps = 5
+        _install_scripted_actions(
+            trainer,
+            move_action=Action.RIGHT,
+            pick_action=make_pick_action(0),
+        )
+
+        before_params = _clone_actor_params(trainer.actor_networks)
+
+        state = State(
+            agent_positions=(Grid(0, 0), Grid(2, 2)),
+            task_positions=(Grid(0, 1),),
+            actor=0,
+            task_types=(0,),
+        )
+
+        trainer.step(state, t=0)
+
+        for actor_before, actor_after in zip(before_params, trainer.actor_networks):
+            for name, tensor in actor_after.state_dict().items():
+                torch.testing.assert_close(actor_before[name], tensor, atol=0.0, rtol=0.0)
+
+    def test_warmup_resumes_critic_updates_after_threshold(self):
+        _, trainer = _make_actor_critic_trainer(PickMode.CHOICE)
+        trainer._warmup_steps = 5
+        spy = _install_identity_critic_spy(trainer)
+        _install_scripted_actions(
+            trainer,
+            move_action=Action.RIGHT,
+            pick_action=make_pick_action(0),
+        )
+
+        sentinel_after = State(
+            agent_positions=(Grid(2, 0), Grid(2, 2)),
+            task_positions=(),
+            actor=1,
+            task_types=(),
+        )
+        trainer._critic_prev_after = sentinel_after
+
+        state = State(
+            agent_positions=(Grid(0, 0), Grid(2, 2)),
+            task_positions=(Grid(0, 1),),
+            actor=0,
+            task_types=(0,),
+        )
+
+        trainer.step(state, t=5)
+
+        assert len(spy["td_calls"]) == 2
+        assert trainer._critic_prev_after is not None
+
+    def test_warmup_does_not_skip_following_rate_alpha_updates(self):
+        env_cfg = EnvConfig(
+            height=3,
+            width=3,
+            n_agents=2,
+            n_tasks=1,
+            gamma=0.5,
+            r_picker=1.0,
+            n_task_types=1,
+            r_low=0.0,
+            task_assignments=((0,), (0,)),
+            pick_mode=PickMode.CHOICE,
+            max_tasks_per_type=1,
+            stochastic=StochasticConfig(spawn_prob=0.0, despawn_mode=None, despawn_prob=0.0),
+        )
+        model_cfg = ModelConfig(
+            encoder=EncoderType.BLIND_TASK_CNN_GRID,
+            mlp_dims=(8,),
+            conv_specs=((4, 3),),
+        )
+        train_cfg = TrainConfig(
+            total_steps=1,
+            seed=7,
+            lr=ScheduleConfig(start=0.0, end=0.0),
+            epsilon=ScheduleConfig(start=0.0, end=0.0),
+            actor_lr=ScheduleConfig(start=0.0, end=0.0),
+            algorithm=AlgorithmConfig(name=AlgorithmName.ACTOR_CRITIC),
+            freeze_critic=True,
+            following_rates=FollowingRatesConfig(
+                enabled=True,
+                budget=1.0,
+                rho=1.0,
+                reallocation_freq=1,
+                fixed=True,
+            ),
+            learning_type=LearningType.DECENTRALIZED,
+            use_gpu=False,
+            td_lambda=0.0,
+            heuristic=Heuristic.NEAREST_TASK,
+            stopping=StoppingConfig(),
+            warmup_steps=100,
+        )
+        cfg = ExperimentConfig(
+            env=env_cfg,
+            model=model_cfg,
+            actor_model=None,
+            train=train_cfg,
+            eval=EvalConfig(),
+            logging=LoggingConfig(output_dir="unused"),
+        )
+        encoding.init_encoder(model_cfg.encoder, env_cfg)
+        env = create_env(env_cfg)
+        trainer = create_trainer(cfg, env)
+
+        def _critic_values_for_after_states(self, state, after_states):
+            return [
+                [10.0 * len(s.task_positions) for _ in range(self._n_agents)]
+                for s in after_states
+            ]
+
+        trainer._critic_values_for_after_states = MethodType(
+            _critic_values_for_after_states, trainer
+        )
+
+        pick_state = State(
+            agent_positions=(Grid(1, 1), Grid(2, 2)),
+            task_positions=(Grid(1, 1),),
+            actor=0,
+            task_types=(0,),
+            pick_phase=True,
+        )
+        legal_mask = build_phase2_legal_mask(pick_state, env.cfg)
+        actor_state = trainer._encode_actor_state(pick_state, 0)
+        probs = trainer._actor_networks_list[0].get_action_probabilities(actor_state, legal_mask)
+
+        prev_decision_count = trainer._decision_count
+        trainer._train_decision(
+            state=pick_state,
+            action=make_pick_action(0),
+            legal_mask=legal_mask,
+            discount=1.0,
+            t=0,
+            actor_state=actor_state,
+            probs=probs,
+        )
+
+        assert trainer._decision_count == prev_decision_count + 1
+        assert not np.isclose(trainer._following_states[1].agent_alphas[0], 0.0)
+
+    def test_alpha_update_uses_stay_baseline(self):
+        env_cfg = EnvConfig(
+            height=3,
+            width=3,
+            n_agents=2,
+            n_tasks=1,
+            gamma=0.5,
+            r_picker=1.0,
+            n_task_types=1,
+            r_low=0.0,
+            task_assignments=((0,), (0,)),
+            pick_mode=PickMode.CHOICE,
+            max_tasks_per_type=1,
+            stochastic=StochasticConfig(spawn_prob=0.0, despawn_mode=None, despawn_prob=0.0),
+        )
+        model_cfg = ModelConfig(
+            encoder=EncoderType.BLIND_TASK_CNN_GRID,
+            mlp_dims=(8,),
+            conv_specs=((4, 3),),
+        )
+        train_cfg = TrainConfig(
+            total_steps=1,
+            seed=7,
+            lr=ScheduleConfig(start=0.0, end=0.0),
+            epsilon=ScheduleConfig(start=0.0, end=0.0),
+            actor_lr=ScheduleConfig(start=0.0, end=0.0),
+            algorithm=AlgorithmConfig(name=AlgorithmName.ACTOR_CRITIC),
+            freeze_critic=True,
+            following_rates=FollowingRatesConfig(
+                enabled=True,
+                budget=1.0,
+                rho=1.0,
+                reallocation_freq=1,
+                fixed=True,
+            ),
+            learning_type=LearningType.DECENTRALIZED,
+            use_gpu=False,
+            td_lambda=0.0,
+            heuristic=Heuristic.NEAREST_TASK,
+            stopping=StoppingConfig(),
+        )
+        cfg = ExperimentConfig(
+            env=env_cfg,
+            model=model_cfg,
+            actor_model=None,
+            train=train_cfg,
+            eval=EvalConfig(),
+            logging=LoggingConfig(output_dir="unused"),
+        )
+        encoding.init_encoder(model_cfg.encoder, env_cfg)
+        env = create_env(env_cfg)
+        trainer = create_trainer(cfg, env)
+
+        def _critic_values_for_after_states(self, state, after_states):
+            return [
+                [10.0 * len(s.task_positions) for _ in range(self._n_agents)]
+                for s in after_states
+            ]
+
+        trainer._critic_values_for_after_states = MethodType(
+            _critic_values_for_after_states, trainer
+        )
+
+        pick_state = State(
+            agent_positions=(Grid(1, 1), Grid(2, 2)),
+            task_positions=(Grid(1, 1),),
+            actor=0,
+            task_types=(0,),
+            pick_phase=True,
+        )
+        legal_mask = build_phase2_legal_mask(pick_state, env.cfg)
+        actor_state = trainer._encode_actor_state(pick_state, 0)
+        probs = trainer._actor_networks_list[0].get_action_probabilities(actor_state, legal_mask)
+
+        trainer._train_decision(
+            state=pick_state,
+            action=make_pick_action(0),
+            legal_mask=legal_mask,
+            discount=1.0,
+            t=0,
+            actor_state=actor_state,
+            probs=probs,
+        )
+
+        # Pick removes the only task → after_state has 0 tasks → V(after_pick) = 0
+        # Stay keeps the task → after_state has 1 task → V(after_stay) = 10
+        # Pick rewards: (1.0, 0.0); Stay rewards: (0.0, 0.0); discount = 1.0
+        # Old definition would store Q1(s, pick) = 0 + 1.0*0 = 0
+        # New definition stores Q1(s, pick) - Q1(s, Stay) = 0 - 10 = -10
+        assert np.isclose(trainer._following_states[1].agent_alphas[0], -10.0)
+        # Actor's own following state never updates its self-edge
+        assert trainer._following_states[0].agent_alphas[0] == 0.0
+        # Other observer dimensions of the non-actor remain at their initial values
+        assert trainer._following_states[0].agent_alphas[1] == 0.0
+
     def test_freeze_critic_skips_critic_updates(self):
         _, trainer = _make_actor_critic_trainer(PickMode.CHOICE)
         trainer._freeze_critic = True

--- a/systematic_debug_report/orchard/tests/test_config.py
+++ b/systematic_debug_report/orchard/tests/test_config.py
@@ -241,3 +241,54 @@ train:
         with pytest.raises(ValueError, match="train.freeze_critic is only supported"):
             load_config(path)
         os.unlink(path)
+
+
+class TestWarmupSteps:
+    def test_warmup_steps_default_is_zero(self):
+        path = _write_yaml(VALID_YAML)
+        cfg = load_config(path)
+        assert cfg.train.warmup_steps == 0
+        os.unlink(path)
+
+    def test_warmup_steps_custom_value_parses(self):
+        yaml_str = VALID_YAML + """
+train:
+  total_steps: 100
+  lr:
+    start: 0.001
+  algorithm:
+    name: actor_critic
+  warmup_steps: 250
+"""
+        path = _write_yaml(yaml_str)
+        cfg = load_config(path)
+        assert cfg.train.warmup_steps == 250
+        os.unlink(path)
+
+    def test_warmup_steps_negative_raises(self):
+        yaml_str = VALID_YAML + """
+train:
+  total_steps: 100
+  lr:
+    start: 0.001
+  algorithm:
+    name: actor_critic
+  warmup_steps: -1
+"""
+        path = _write_yaml(yaml_str)
+        with pytest.raises(ValueError, match="train.warmup_steps must be >= 0"):
+            load_config(path)
+        os.unlink(path)
+
+    def test_warmup_steps_requires_actor_critic(self):
+        yaml_str = VALID_YAML + """
+train:
+  total_steps: 100
+  lr:
+    start: 0.001
+  warmup_steps: 100
+"""
+        path = _write_yaml(yaml_str)
+        with pytest.raises(ValueError, match="train.warmup_steps>0 requires train.algorithm.name=actor_critic"):
+            load_config(path)
+        os.unlink(path)

--- a/systematic_debug_report/orchard/tests/test_eval.py
+++ b/systematic_debug_report/orchard/tests/test_eval.py
@@ -28,11 +28,11 @@ class TestRolloutTrajectory:
             actor=0, task_types=(0,)
         )
         
-        def dummy_policy(state, phase2=False):
+        def dummy_policy(state):
             return Action.RIGHT
-            
+
         transitions = list(rollout_trajectory(s, dummy_policy, env, n_steps=1))
-        
+
         # Should be exactly 1 transition (just the move)
         assert len(transitions) == 1
         t = transitions[0]
@@ -51,8 +51,8 @@ class TestRolloutTrajectory:
             actor=0, task_types=(0,)
         )
         
-        def dummy_policy(state, phase2=False):
-            return Action.RIGHT # Move right onto the task
+        def dummy_policy(state):
+            return Action.RIGHT  # Move right onto the task
             
         transitions = list(rollout_trajectory(s, dummy_policy, env, n_steps=1))
         
@@ -78,11 +78,10 @@ class TestRolloutTrajectory:
             actor=0, task_types=(0,)
         )
         
-        def choice_policy(state, phase2=False):
-            if phase2:
-                assert state.pick_phase is True
-                return Action.STAY # Decline the pick!
-            return Action.RIGHT # Phase 1: Move right
+        def choice_policy(state):
+            if state.pick_phase:
+                return Action.STAY  # Decline the pick!
+            return Action.RIGHT  # Phase 1: Move right
             
         transitions = list(rollout_trajectory(s, choice_policy, env, n_steps=1))
         
@@ -108,13 +107,12 @@ class TestEvaluatePolicyMetrics:
         
         # A scripted policy that takes exactly 2 steps to pick a correct task and a wrong task
         step_counter = 0
-        def scripted_policy(state, phase2=False):
+        def scripted_policy(state):
             nonlocal step_counter
-            if not phase2:
+            if not state.pick_phase:
                 step_counter += 1
-                return Action.RIGHT # Step 1 lands on type 0, Step 2 lands on type 1
+                return Action.RIGHT  # Step 1 lands on type 0, Step 2 lands on type 1
             else:
-                # Always pick what we are standing on
                 tau = state.task_type_at(state.agent_positions[state.actor])
                 return make_pick_action(tau)
 

--- a/systematic_debug_report/orchard/tests/test_policy.py
+++ b/systematic_debug_report/orchard/tests/test_policy.py
@@ -98,9 +98,9 @@ class TestHeuristicPolicies:
             actor=0, task_types=(1,)
         )
         # Phase 2 logic: should STAY because it's the wrong type
-        action_wrong = nearest_correct_task_stay_wrong_action(s_wrong, cfg, phase2=True)
+        action_wrong = nearest_correct_task_stay_wrong_action(s_wrong.with_pick_phase(), cfg)
         assert action_wrong == Action.STAY
-        
+
         # Actor 0 standing on a Type 0 task
         s_correct = State(
             agent_positions=(Grid(2, 2), Grid(1, 1), Grid(1, 2), Grid(1, 3)),
@@ -108,7 +108,7 @@ class TestHeuristicPolicies:
             actor=0, task_types=(0,)
         )
         # Phase 2 logic: should pick because it's the correct type
-        action_correct = nearest_correct_task_stay_wrong_action(s_correct, cfg, phase2=True)
+        action_correct = nearest_correct_task_stay_wrong_action(s_correct.with_pick_phase(), cfg)
         assert action_correct == make_pick_action(0)
 
     def test_heuristic_dispatch(self):

--- a/systematic_debug_report/orchard/train.py
+++ b/systematic_debug_report/orchard/train.py
@@ -82,7 +82,7 @@ def train(cfg: ExperimentConfig, resume_checkpoint: str | None = None, resume_cr
 
     # --- Logging ---
     run_dir = setup_logging(cfg)
-    trainer.setup_aux_loggers(run_dir)
+    trainer.setup_aux_loggers(run_dir, alpha_state_log_freq=cfg.logging.alpha_state_log_freq)
     trainer.save_checkpoint(run_dir / "checkpoints" / "step_0.pt", 0)
 
     heuristic_name = cfg.train.heuristic.name.lower()

--- a/systematic_debug_report/orchard/trainer/__init__.py
+++ b/systematic_debug_report/orchard/trainer/__init__.py
@@ -54,6 +54,7 @@ def create_trainer(
                 following_rates_cfg=cfg.train.following_rates,
                 influencer_cfg=cfg.train.influencer,
                 timer=timer,
+                warmup_steps=cfg.train.warmup_steps,
             )
         from orchard.trainer.actor_critic import ActorCriticCpuTrainer
         print(f"ActorCriticCpuTrainer: {len(critics)} critics on CPU")
@@ -70,6 +71,7 @@ def create_trainer(
             following_rates_cfg=cfg.train.following_rates,
             influencer_cfg=cfg.train.influencer,
             timer=timer,
+            warmup_steps=cfg.train.warmup_steps,
         )
 
     networks = create_networks(cfg.model, cfg.env, cfg.train)

--- a/systematic_debug_report/orchard/trainer/actor_critic.py
+++ b/systematic_debug_report/orchard/trainer/actor_critic.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+import json
 from pathlib import Path
 from typing import Any
 
@@ -165,6 +166,8 @@ class ActorCriticTrainerBase(TrainerBase):
         self._phase2_logger: CSVLogger | None = None
         self._following_loggers: dict[int, CSVLogger] = {}
         self._influencer_logger: CSVLogger | None = None
+        self._alpha_state_log: Any = None  # open file handle for alpha_states.jsonl
+        self._alpha_state_log_freq: int = 0
         self._phase1_eval_states: list[State] | None = None
         self._phase2_eval_states: list[tuple[str, State]] | None = None
 
@@ -660,13 +663,18 @@ class ActorCriticTrainerBase(TrainerBase):
             stay_idx = int(Action.STAY.value)
             stay_rewards = rewards_by_action[stay_idx]
             stay_after_values = after_values_by_action[stay_idx]
-            alpha_estimates = [
-                (float(selected_rewards[idx]) + float(discount) * float(selected_after_values[idx]))
-                - (float(stay_rewards[idx]) + float(discount) * float(stay_after_values[idx]))
-                for idx in range(self._n_agents)
-            ]
+            reward_diffs = [float(selected_rewards[i]) - float(stay_rewards[i]) for i in range(self._n_agents)]
+            value_diffs = [float(selected_after_values[i]) - float(stay_after_values[i]) for i in range(self._n_agents)]
+            alpha_estimates = [reward_diffs[i] + discount * value_diffs[i] for i in range(self._n_agents)]
         else:
+            reward_diffs = []
+            value_diffs = []
             alpha_estimates = []
+        selected_after_state = after_states_by_action[action_idx]
+        after_actor_pos = (selected_after_state.agent_positions[actor_id].row,
+                           selected_after_state.agent_positions[actor_id].col)
+        self._log_alpha_state(state, actor_id, alpha_estimates, action_idx, after_actor_pos,
+                              reward_diffs, value_diffs, discount, t)
         self._postprocess_selected_returns(actor_id, alpha_estimates)
 
         selected_after_state = after_states_by_action[action_idx]
@@ -776,7 +784,8 @@ class ActorCriticTrainerBase(TrainerBase):
                 row[f"actor_grad_norm_agent_{idx}_{name}"] = round(val, 6)
         return row
 
-    def setup_aux_loggers(self, run_dir: Path) -> None:
+    def setup_aux_loggers(self, run_dir: Path, alpha_state_log_freq: int = 0) -> None:
+        self._alpha_state_log_freq = alpha_state_log_freq
         self._phase1_logger = CSVLogger(
             run_dir / "phase1_policy_probabilities.csv",
             build_phase1_policy_prob_csv_fieldnames(self._env.cfg.n_task_types),
@@ -799,6 +808,55 @@ class ActorCriticTrainerBase(TrainerBase):
                 run_dir / "external_influencer.csv",
                 build_influencer_csv_fieldnames(self._n_agents),
             )
+        if alpha_state_log_freq > 0 and self._following_states:
+            self._alpha_state_log = open(run_dir / "alpha_states.jsonl", "w")
+
+    def _log_alpha_state(
+        self,
+        state: State,
+        actor_id: int,
+        alpha_estimates: list[float],
+        action_idx: int,
+        after_actor_pos: tuple[int, int],
+        reward_diffs: list[float],
+        value_diffs: list[float],
+        discount: float,
+        t: int,
+    ) -> None:
+        if self._alpha_state_log is None:
+            return
+        freq = self._alpha_state_log_freq
+        if freq <= 0 or t % freq != 0:
+            return
+        assignments = self._env.cfg.task_assignments or ()
+        actor_types = set(assignments[actor_id]) if actor_id < len(assignments) else set()
+        teammate_of_actor = [
+            i != actor_id and bool(set(assignments[i]) & actor_types if i < len(assignments) else False)
+            for i in range(self._n_agents)
+        ]
+        record = {
+            "step": t,
+            "actor_id": actor_id,
+            "action_idx": action_idx,
+            "pick_phase": bool(state.pick_phase),
+            "discount": discount,
+            # current state (before action)
+            "agent_positions": [[p.row, p.col] for p in state.agent_positions],
+            "task_positions": (
+                [[p.row, p.col, int(tt)] for p, tt in zip(state.task_positions, state.task_types)]
+                if state.task_positions and state.task_types is not None else []
+            ),
+            # where the actor ends up after the selected action
+            "actor_after_pos": list(after_actor_pos),
+            "teammate_of_actor": teammate_of_actor,
+            # per-observer decomposition
+            "reward_diffs": reward_diffs,
+            "value_diffs": value_diffs,
+            "gamma_value_diffs": [discount * v for v in value_diffs],
+            "alpha_estimates": alpha_estimates,
+        }
+        self._alpha_state_log.write(json.dumps(record) + "\n")
+        self._alpha_state_log.flush()
 
     def log_auxiliary(self, step: int, wall_time: float) -> None:
         if self._phase1_logger is not None and self._phase1_eval_states is not None:
@@ -1135,9 +1193,20 @@ class ActorCriticGpuTrainer(ActorCriticTrainerBase):
                 torch.as_tensor(stay_rewards, dtype=stay_after_values_t.dtype, device=device) +
                 float(discount) * stay_after_values_t
             )
+            reward_diffs = (torch.as_tensor(selected_rewards, dtype=selected_after_values_t.dtype, device=device)
+                            - torch.as_tensor(stay_rewards, dtype=stay_after_values_t.dtype, device=device)
+                            ).detach().cpu().tolist()
+            value_diffs = (selected_after_values_t - stay_after_values_t).detach().cpu().tolist()
             alpha_estimates = (selected_one_step_t - stay_one_step_t).detach().cpu().tolist()
         else:
+            reward_diffs = []
+            value_diffs = []
             alpha_estimates = []
+        selected_after_state = after_states[action_pos]
+        after_actor_pos = (selected_after_state.agent_positions[actor_id].row,
+                           selected_after_state.agent_positions[actor_id].col)
+        self._log_alpha_state(state, actor_id, alpha_estimates, action_idx, after_actor_pos,
+                              reward_diffs, value_diffs, discount, t)
         self._postprocess_selected_returns(actor_id, alpha_estimates)
 
         selected_after_state = after_states[action_pos]

--- a/systematic_debug_report/orchard/trainer/actor_critic.py
+++ b/systematic_debug_report/orchard/trainer/actor_critic.py
@@ -94,6 +94,7 @@ class ActorCriticTrainerBase(TrainerBase):
         following_rates_cfg: FollowingRatesConfig,
         influencer_cfg: InfluencerConfig,
         timer: Timer | None = None,
+        warmup_steps: int = 0,
     ) -> None:
         self._critic_networks_list = critic_networks
         self._actor_networks_list = actor_networks
@@ -104,6 +105,7 @@ class ActorCriticTrainerBase(TrainerBase):
         self._total_steps = int(total_steps)
         self._heuristic = heuristic
         self._freeze_critic = bool(freeze_critic)
+        self._warmup_steps = max(0, int(warmup_steps))
         self._timer = timer or Timer()
         self._n_agents = env.cfg.n_agents
         self._decision_count = 0
@@ -224,6 +226,8 @@ class ActorCriticTrainerBase(TrainerBase):
         advantage: float,
         t: int,
     ) -> None:
+        if t < self._warmup_steps:
+            return
         self._timer.start(TimerSection.TRAIN)
         actor_lr = compute_schedule_value(self._actor_lr_schedule, t, self._total_steps)
         actor_net.set_lr(actor_lr)
@@ -582,7 +586,7 @@ class ActorCriticTrainerBase(TrainerBase):
         discount: float,
         t: int,
     ) -> None:
-        if self._freeze_critic:
+        if self._freeze_critic or t < self._warmup_steps:
             self._critic_prev_after = None
             return
 
@@ -608,14 +612,14 @@ class ActorCriticTrainerBase(TrainerBase):
     def _postprocess_selected_returns(
         self,
         actor_id: int,
-        selected_returns: list[float],
+        alpha_estimates: list[float],
     ) -> None:
         if self._following_states:
             rho = float(self._following_rates_cfg.rho)
             for observer_id, observer_state in enumerate(self._following_states):
                 if observer_id == actor_id:
                     continue
-                observer_state.update_alpha(actor_id, float(selected_returns[observer_id]), rho)
+                observer_state.update_alpha(actor_id, float(alpha_estimates[observer_id]), rho)
             self._refresh_influencer_beta()
             self._refresh_follower_influencer_values()
             self._decision_count += 1
@@ -652,11 +656,18 @@ class ActorCriticTrainerBase(TrainerBase):
         advantage = selected_q_value - baseline_value
         selected_rewards = rewards_by_action[action_idx]
         selected_after_values = after_values_by_action[action_idx]
-        selected_returns = [
-            float(selected_rewards[idx]) + float(discount) * float(selected_after_values[idx])
-            for idx in range(self._n_agents)
-        ]
-        self._postprocess_selected_returns(actor_id, selected_returns)
+        if self._following_states:
+            stay_idx = int(Action.STAY.value)
+            stay_rewards = rewards_by_action[stay_idx]
+            stay_after_values = after_values_by_action[stay_idx]
+            alpha_estimates = [
+                (float(selected_rewards[idx]) + float(discount) * float(selected_after_values[idx]))
+                - (float(stay_rewards[idx]) + float(discount) * float(stay_after_values[idx]))
+                for idx in range(self._n_agents)
+            ]
+        else:
+            alpha_estimates = []
+        self._postprocess_selected_returns(actor_id, alpha_estimates)
 
         selected_after_state = after_states_by_action[action_idx]
         self._train_critic_after_transition(
@@ -985,6 +996,7 @@ class ActorCriticGpuTrainer(ActorCriticTrainerBase):
         following_rates_cfg: FollowingRatesConfig,
         influencer_cfg: InfluencerConfig,
         timer: Timer | None = None,
+        warmup_steps: int = 0,
     ) -> None:
         super().__init__(
             critic_networks=critic_networks,
@@ -999,6 +1011,7 @@ class ActorCriticGpuTrainer(ActorCriticTrainerBase):
             following_rates_cfg=following_rates_cfg,
             influencer_cfg=influencer_cfg,
             timer=timer,
+            warmup_steps=warmup_steps,
         )
         self._bt = bt
 
@@ -1110,11 +1123,22 @@ class ActorCriticGpuTrainer(ActorCriticTrainerBase):
 
         selected_rewards = rewards_list[action_pos]
         selected_after_values_t = after_values_t[action_pos]
-        selected_returns = (
-            torch.as_tensor(selected_rewards, dtype=selected_after_values_t.dtype, device=device) +
-            float(discount) * selected_after_values_t
-        ).detach().cpu().tolist()
-        self._postprocess_selected_returns(actor_id, selected_returns)
+        if self._following_states:
+            stay_pos = legal_indices.index(int(Action.STAY.value))
+            stay_rewards = rewards_list[stay_pos]
+            stay_after_values_t = after_values_t[stay_pos]
+            selected_one_step_t = (
+                torch.as_tensor(selected_rewards, dtype=selected_after_values_t.dtype, device=device) +
+                float(discount) * selected_after_values_t
+            )
+            stay_one_step_t = (
+                torch.as_tensor(stay_rewards, dtype=stay_after_values_t.dtype, device=device) +
+                float(discount) * stay_after_values_t
+            )
+            alpha_estimates = (selected_one_step_t - stay_one_step_t).detach().cpu().tolist()
+        else:
+            alpha_estimates = []
+        self._postprocess_selected_returns(actor_id, alpha_estimates)
 
         selected_after_state = after_states[action_pos]
         self._train_critic_after_transition(

--- a/systematic_debug_report/orchard/trainer/actor_critic.py
+++ b/systematic_debug_report/orchard/trainer/actor_critic.py
@@ -297,7 +297,7 @@ class ActorCriticTrainerBase(TrainerBase):
         self._timer.step_begin()
 
         self._timer.start(TimerSection.ACTION)
-        move_action, move_actor_state, move_probs, move_mask = self._sample_action(state, phase2=False)
+        move_action, move_actor_state, move_probs, move_mask = self._sample_action(state)
         self._timer.stop()
 
         self._timer.start(TimerSection.ENV)
@@ -319,10 +319,7 @@ class ActorCriticTrainerBase(TrainerBase):
             )
 
             self._timer.start(TimerSection.ACTION)
-            pick_action, pick_actor_state, pick_probs, pick_mask = self._sample_action(
-                pick_state,
-                phase2=True,
-            )
+            pick_action, pick_actor_state, pick_probs, pick_mask = self._sample_action(pick_state)
             self._timer.stop()
 
             self._timer.start(TimerSection.ENV)
@@ -387,30 +384,29 @@ class ActorCriticTrainerBase(TrainerBase):
         enc = encoding.encode(state, actor_id)
         return _move_encoder_output_to_device(enc, self._actor_device(actor_id))
 
-    def _legal_mask(self, state: State, phase2: bool) -> np.ndarray:
-        if phase2:
+    def _legal_mask(self, state: State) -> np.ndarray:
+        if state.pick_phase:
             return build_phase2_legal_mask(state, self._env.cfg)
         return build_phase1_legal_mask(state, self._env.cfg)
 
-    def _actor_probabilities(self, state: State, phase2: bool) -> np.ndarray:
+    def _actor_probabilities(self, state: State) -> np.ndarray:
         actor_id = state.actor
         actor_state = self._encode_actor_state(state, actor_id)
-        legal_mask = self._legal_mask(state, phase2)
+        legal_mask = self._legal_mask(state)
         return self._actor_networks_list[actor_id].get_action_probabilities(actor_state, legal_mask)
 
     def _sample_action(
         self,
         state: State,
-        phase2: bool,
     ) -> tuple[Action, EncoderOutput, np.ndarray | torch.Tensor, np.ndarray]:
         actor_id = state.actor
         actor_state = self._encode_actor_state(state, actor_id)
-        legal_mask = self._legal_mask(state, phase2)
+        legal_mask = self._legal_mask(state)
         action, probs = self._actor_networks_list[actor_id].sample_action(actor_state, legal_mask)
         return action, actor_state, probs, legal_mask
 
-    def _greedy_action(self, state: State, phase2: bool) -> Action:
-        probs = self._actor_probabilities(state, phase2)
+    def _greedy_action(self, state: State) -> Action:
+        probs = self._actor_probabilities(state)
         return policy_index_to_action(int(np.argmax(probs)))
 
     # ------------------------------------------------------------------
@@ -700,11 +696,11 @@ class ActorCriticTrainerBase(TrainerBase):
     def evaluate(self, env: BaseEnv, eval_cfg: EvalConfig) -> dict[str, float | int]:
         eval_start = env.init_state()
 
-        def greedy_policy(s: State, phase2: bool = False) -> Action:
-            return self._greedy_action(s, phase2=phase2)
+        def greedy_policy(s: State) -> Action:
+            return self._greedy_action(s)
 
-        def baseline_policy(s: State, phase2: bool = False) -> Action:
-            return heuristic_action(s, env.cfg, self._heuristic, phase2=phase2)
+        def baseline_policy(s: State) -> Action:
+            return heuristic_action(s, env.cfg, self._heuristic)
 
         heuristic_name = self._heuristic.name.lower()
         greedy_metrics = evaluate_policy_metrics(eval_start, greedy_policy, env, eval_cfg.eval_steps)
@@ -861,13 +857,13 @@ class ActorCriticTrainerBase(TrainerBase):
     def log_auxiliary(self, step: int, wall_time: float) -> None:
         if self._phase1_logger is not None and self._phase1_eval_states is not None:
             for idx, state in enumerate(self._phase1_eval_states):
-                probs = self._actor_probabilities(state, phase2=False)
+                probs = self._actor_probabilities(state)
                 self._phase1_logger.log(
                     build_phase1_policy_prob_row(step, wall_time, idx, state, probs, self._env.cfg)
                 )
         if self._phase2_logger is not None and self._phase2_eval_states is not None:
             for idx, (label, state) in enumerate(self._phase2_eval_states):
-                probs = self._actor_probabilities(state, phase2=True)
+                probs = self._actor_probabilities(state)
                 self._phase2_logger.log(
                     build_phase2_policy_prob_row(step, wall_time, idx, label, state, probs, self._env.cfg)
                 )
@@ -1134,11 +1130,10 @@ class ActorCriticGpuTrainer(ActorCriticTrainerBase):
     def _sample_action(
         self,
         state: State,
-        phase2: bool,
     ) -> tuple[Action, EncoderOutput, np.ndarray | torch.Tensor, np.ndarray]:
         actor_id = state.actor
         actor_state = self._encode_actor_state(state, actor_id)
-        legal_mask = self._legal_mask(state, phase2)
+        legal_mask = self._legal_mask(state)
         probs_t = self._actor_networks_list[actor_id].get_action_probabilities_tensor(actor_state, legal_mask)
         action_idx = int(torch.multinomial(probs_t, 1).item())
         return policy_index_to_action(action_idx), actor_state, probs_t, legal_mask

--- a/systematic_debug_report/orchard/trainer/base.py
+++ b/systematic_debug_report/orchard/trainer/base.py
@@ -40,8 +40,8 @@ class TrainerBase(ABC):
     def get_detail_metrics(self) -> dict[str, float | int | str]:
         return {}
 
-    def setup_aux_loggers(self, run_dir: Path) -> None:
-        del run_dir
+    def setup_aux_loggers(self, run_dir: Path, alpha_state_log_freq: int = 0) -> None:
+        del run_dir, alpha_state_log_freq
 
     def log_auxiliary(self, step: int, wall_time: float) -> None:
         del step, wall_time

--- a/systematic_debug_report/orchard/trainer/value_base.py
+++ b/systematic_debug_report/orchard/trainer/value_base.py
@@ -106,7 +106,7 @@ class ValueTrainerBase(TrainerBase):
         self.train_move(s_moved, on_task, t)
 
         if on_task:
-            pick_action = self.select_pick(s_moved, t)
+            pick_action = self.select_pick(s_moved.with_pick_phase(), t)
             self._timer.start(TimerSection.ENV)
             s_picked, pick_rewards = self._env.resolve_pick(
                 s_moved,
@@ -132,7 +132,7 @@ class ValueTrainerBase(TrainerBase):
         if rng.random() < eps:
             action = actions[rng.randint(0, len(actions) - 1)]
         else:
-            action = self._greedy_action(state, phase2=False)
+            action = self._greedy_action(state)
         self._timer.stop()
         return action
 
@@ -143,12 +143,13 @@ class ValueTrainerBase(TrainerBase):
         if rng.random() < eps:
             action = actions[rng.randint(0, len(actions) - 1)]
         else:
-            action = self._greedy_action(state, phase2=True)
+            action = self._greedy_action(state)
         self._timer.stop()
         return action
 
-    def _greedy_action(self, state: State, phase2: bool) -> Action:
+    def _greedy_action(self, state: State) -> Action:
         """Argmax over Q_team = immediate_reward + weighted sum of V_i(after_state)."""
+        phase2 = state.pick_phase
         all_actions = get_phase2_actions(state, self._env.cfg) if phase2 else get_all_actions(self._env.cfg)
         actor = state.actor
 
@@ -166,7 +167,7 @@ class ValueTrainerBase(TrainerBase):
             elif phase2:
                 after_states.append(state)
                 immediate_rewards.append(0.0)
-            else:
+            else: #
                 s = self._env.apply_action(state, a)
                 if s.is_agent_on_task(s.actor):
                     after_states.append(s.with_pick_phase())
@@ -229,11 +230,11 @@ class ValueTrainerBase(TrainerBase):
         from orchard.eval import evaluate_policy_metrics
         eval_start = env.init_state()
 
-        def greedy_policy(s: State, phase2: bool = False) -> Action:
-            return self._greedy_action(s, phase2=phase2)
+        def greedy_policy(s: State) -> Action:
+            return self._greedy_action(s)
 
-        def baseline_policy(s: State, phase2: bool = False) -> Action:
-            return heuristic_action(s, env.cfg, self._heuristic, phase2=phase2)
+        def baseline_policy(s: State) -> Action:
+            return heuristic_action(s, env.cfg, self._heuristic)
 
         heuristic_name = self._heuristic.name.lower()
         greedy_metrics = evaluate_policy_metrics(eval_start, greedy_policy, env, eval_cfg.eval_steps)

--- a/systematic_debug_report/orchard/viz/__main__.py
+++ b/systematic_debug_report/orchard/viz/__main__.py
@@ -118,12 +118,11 @@ def _greedy_actor_action(
     state: State,
     actor_networks: list[PolicyNetwork],
     env,
-    phase2: bool = False,
 ) -> Action:
     """Greedy action via actor network argmax (no critic involved)."""
     actor_id = state.actor
     enc = encoding.encode(state, actor_id)
-    legal_mask = build_phase2_legal_mask(state, env.cfg) if phase2 else build_phase1_legal_mask(state, env.cfg)
+    legal_mask = build_phase2_legal_mask(state, env.cfg) if state.pick_phase else build_phase1_legal_mask(state, env.cfg)
     with torch.no_grad():
         probs = actor_networks[actor_id].get_action_probabilities(enc, legal_mask)
     return policy_index_to_action(int(np.argmax(probs)))
@@ -133,10 +132,10 @@ def _greedy_action_batched(
     state: State,
     networks: list[ValueNetwork],
     env,
-    phase2: bool = False,
     comm_weight: float = 0.0,
 ) -> Action:
     """Standalone greedy argmax over Q_team for viz (no trainer needed)."""
+    phase2 = state.pick_phase
     all_actions = get_phase2_actions(state, env.cfg) if phase2 else get_all_actions(env.cfg)
     actor = state.actor
     centralized = (len(networks) == 1)
@@ -198,35 +197,32 @@ def make_policy_fn(
     comm_weight: float = 0.0,
     actor_networks: list[PolicyNetwork] | None = None,
 ):
-    """Return a policy function: (State, bool) -> Action.
+    """Return a policy function: State -> Action.
 
-    The second argument is *phase2*: True when the actor has landed on a
-    task and is deciding whether / what to pick (CHOICE mode).
-    In FORCED mode, rollout_trajectory handles the pick automatically
-    and never calls the policy with phase2=True.
+    Phase is determined by state.pick_phase. In FORCED mode, rollout_trajectory
+    handles the pick automatically and never calls the policy in pick phase.
 
     If actor_networks is provided, 'learned' uses actor argmax (actor_critic mode).
     Otherwise, 'learned' uses critic argmax (value mode).
     """
     if policy_name == "learned":
         if actor_networks is not None:
-            def policy(s: State, phase2: bool = False) -> Action:
-                return _greedy_actor_action(s, actor_networks, env, phase2=phase2)
+            def policy(s: State) -> Action:
+                return _greedy_actor_action(s, actor_networks, env)
             return policy
         if networks is None:
             raise ValueError("--policy learned requires --checkpoint")
-        def policy(s: State, phase2: bool = False) -> Action:
-            return _greedy_action_batched(s, networks, env, phase2=phase2,
-                                         comm_weight=comm_weight)
+        def policy(s: State) -> Action:
+            return _greedy_action_batched(s, networks, env, comm_weight=comm_weight)
         return policy
     elif policy_name in _HEURISTIC_MAP:
         h = _HEURISTIC_MAP[policy_name]
-        def policy(s: State, phase2: bool = False) -> Action:
-            return heuristic_action(s, env.cfg, h, phase2=phase2)
+        def policy(s: State) -> Action:
+            return heuristic_action(s, env.cfg, h)
         return policy
     elif policy_name == "random":
         n_act = num_actions(env.cfg.pick_mode, env.cfg.n_task_types)
-        def policy(s: State, phase2: bool = False) -> Action:
+        def policy(s: State) -> Action:
             return Action(rng.randint(0, n_act - 1))
         return policy
     else:

--- a/systematic_debug_report/orchard/viz/__main__.py
+++ b/systematic_debug_report/orchard/viz/__main__.py
@@ -9,10 +9,18 @@ from pathlib import Path
 
 import torch
 
+import numpy as np
+
 import orchard.encoding as encoding
+from orchard.actor_critic import (
+    PolicyNetwork,
+    build_phase1_legal_mask,
+    build_phase2_legal_mask,
+    policy_index_to_action,
+)
 from orchard.config import load_config
 from orchard.env import create_env
-from orchard.model import ValueNetwork, create_networks
+from orchard.model import ValueNetwork, create_networks, create_actor_networks
 from orchard.policy import (
     heuristic_action, get_all_actions, get_phase2_actions,
 )
@@ -68,10 +76,15 @@ def parse_args() -> argparse.Namespace:
 def load_checkpoint(
     checkpoint_path: str,
     networks: list[ValueNetwork],
-) -> int:
-    """Load checkpoint into networks. Returns the training step."""
+) -> tuple[int, dict]:
+    """Load critic weights into networks. Returns (training step, raw ckpt dict)."""
     ckpt = torch.load(checkpoint_path, map_location="cpu", weights_only=True)
-    state_dicts = ckpt["networks"]
+    if "networks" in ckpt:
+        state_dicts = ckpt["networks"]
+    elif "critics" in ckpt:
+        state_dicts = ckpt["critics"]
+    else:
+        raise KeyError(f"Checkpoint has neither 'networks' nor 'critics' key. Keys: {list(ckpt.keys())}")
     if len(state_dicts) != len(networks):
         raise ValueError(
             f"Checkpoint has {len(state_dicts)} networks but config specifies "
@@ -80,7 +93,40 @@ def load_checkpoint(
     for net, sd in zip(networks, state_dicts):
         net.load_state_dict(sd, strict=True)
         net.eval()
-    return ckpt.get("step", 0)
+    return ckpt.get("step", 0), ckpt
+
+
+def load_actor_networks(
+    ckpt: dict,
+    actor_networks: list[PolicyNetwork],
+) -> None:
+    """Load actor weights from a checkpoint dict into actor networks."""
+    if "actors" not in ckpt:
+        raise KeyError(f"Checkpoint has no 'actors' key. Keys: {list(ckpt.keys())}")
+    state_dicts = ckpt["actors"]
+    if len(state_dicts) != len(actor_networks):
+        raise ValueError(
+            f"Checkpoint has {len(state_dicts)} actors but config specifies "
+            f"{len(actor_networks)} agents"
+        )
+    for net, sd in zip(actor_networks, state_dicts):
+        net.load_state_dict(sd, strict=True)
+        net.eval()
+
+
+def _greedy_actor_action(
+    state: State,
+    actor_networks: list[PolicyNetwork],
+    env,
+    phase2: bool = False,
+) -> Action:
+    """Greedy action via actor network argmax (no critic involved)."""
+    actor_id = state.actor
+    enc = encoding.encode(state, actor_id)
+    legal_mask = build_phase2_legal_mask(state, env.cfg) if phase2 else build_phase1_legal_mask(state, env.cfg)
+    with torch.no_grad():
+        probs = actor_networks[actor_id].get_action_probabilities(enc, legal_mask)
+    return policy_index_to_action(int(np.argmax(probs)))
 
 
 def _greedy_action_batched(
@@ -94,6 +140,7 @@ def _greedy_action_batched(
     all_actions = get_phase2_actions(state, env.cfg) if phase2 else get_all_actions(env.cfg)
     actor = state.actor
     centralized = (len(networks) == 1)
+    n_nets = len(networks)
 
     after_states: list[State] = []
     immediate_rewards: list[float] = []
@@ -116,15 +163,23 @@ def _greedy_action_batched(
             immediate_rewards.append(0.0)
 
     n_actions = len(after_states)
+
+    # Use encode_all_agents_for_actions to match GPU trainer encoding exactly.
+    # encode_batch_for_actions omits Ch5 (actor position) for the actor's own
+    # encoding, causing wrong critic inputs vs what was seen during training.
+    grids, scalars = encoding.encode_all_agents_for_actions(state, after_states)
+    # grids: (N, B, C, H, W), scalars: (N, B, S)
+
     team_values = [0.0] * n_actions
+    per_agent_vals: list[list[float]] = []
     with torch.no_grad():
         for i, net in enumerate(networks):
-            agent_idx = 0 if centralized else i
-            batch_enc = encoding.encode_batch_for_actions(state, agent_idx, after_states)
-            vals = net(batch_enc)
+            vals = net.forward_raw(grids[i], scalars[i])  # (B,)
+            agent_vals = [vals[k].item() for k in range(n_actions)]
+            per_agent_vals.append(agent_vals)
             weight = 1.0 if (centralized or i == actor) else comm_weight
             for k in range(n_actions):
-                team_values[k] += weight * vals[k].item()
+                team_values[k] += weight * agent_vals[k]
 
     best_idx = 0
     best_val = team_values[0] + immediate_rewards[0]
@@ -141,6 +196,7 @@ def make_policy_fn(
     networks: list[ValueNetwork] | None,
     env,
     comm_weight: float = 0.0,
+    actor_networks: list[PolicyNetwork] | None = None,
 ):
     """Return a policy function: (State, bool) -> Action.
 
@@ -148,8 +204,15 @@ def make_policy_fn(
     task and is deciding whether / what to pick (CHOICE mode).
     In FORCED mode, rollout_trajectory handles the pick automatically
     and never calls the policy with phase2=True.
+
+    If actor_networks is provided, 'learned' uses actor argmax (actor_critic mode).
+    Otherwise, 'learned' uses critic argmax (value mode).
     """
     if policy_name == "learned":
+        if actor_networks is not None:
+            def policy(s: State, phase2: bool = False) -> Action:
+                return _greedy_actor_action(s, actor_networks, env, phase2=phase2)
+            return policy
         if networks is None:
             raise ValueError("--policy learned requires --checkpoint")
         def policy(s: State, phase2: bool = False) -> Action:
@@ -261,18 +324,24 @@ def main() -> None:
     encoding.init_encoder(cfg.model.encoder, cfg.env)
 
     # --- Load checkpoint if provided ---
-    from orchard.enums import LearningType
+    from orchard.enums import LearningType, AlgorithmName
     centralized = cfg.train.learning_type == LearningType.CENTRALIZED
     n_networks = 1 if centralized else cfg.env.n_agents
+    use_actor_argmax = cfg.train.algorithm.name == AlgorithmName.ACTOR_CRITIC
 
     networks: list[ValueNetwork] | None = None
+    actor_networks: list[PolicyNetwork] | None = None
     if args.checkpoint:
         print(f"Loading checkpoint: {args.checkpoint}")
         if centralized:
             print(f"  Centralized mode: creating 1 shared network for {cfg.env.n_agents} agents")
         networks = create_networks(cfg.model, cfg.env, cfg.train)
-        ckpt_step = load_checkpoint(args.checkpoint, networks)
+        ckpt_step, ckpt = load_checkpoint(args.checkpoint, networks)
         print(f"  Loaded checkpoint at training step {ckpt_step}")
+        if use_actor_argmax:
+            print(f"  Algorithm=actor_critic: loading actor networks for argmax")
+            actor_networks = create_actor_networks(cfg.actor_model, cfg.env, cfg.train)
+            load_actor_networks(ckpt, actor_networks)
 
     # --- Determine policy ---
     if args.policy is not None:
@@ -310,7 +379,8 @@ def main() -> None:
     t0 = time.time()
 
     policy_fn = make_policy_fn(policy_name, networks, env,
-                               comm_weight=cfg.train.comm_weight)
+                               comm_weight=cfg.train.comm_weight,
+                               actor_networks=actor_networks)
     frames = generate_frames(
         start_state=init_state,
         policy_fn=policy_fn,
@@ -345,8 +415,10 @@ def main() -> None:
 
         print(f"Rolling out {args.steps} decisions with policy: {compare_name} (compare)")
         env_compare = create_env(cfg.env)
+        compare_actor_networks = actor_networks if compare_name == "learned" else None
         compare_fn = make_policy_fn(compare_name, compare_networks, env_compare,
-                                    comm_weight=cfg.train.comm_weight)
+                                    comm_weight=cfg.train.comm_weight,
+                                    actor_networks=compare_actor_networks)
         compare_frames = generate_frames(
             start_state=init_state,
             policy_fn=compare_fn,

--- a/systematic_debug_report/orchard/viz/rollout.py
+++ b/systematic_debug_report/orchard/viz/rollout.py
@@ -18,7 +18,7 @@ from orchard.viz.frame import Decision, Frame
 
 def generate_frames(
     start_state: State,
-    policy_fn: "Callable[[State, bool], Action]",
+    policy_fn: "Callable[[State], Action]",
     env: BaseEnv,
     n_steps: int,
     policy_name: str = "",


### PR DESCRIPTION
## Summary

Four related changes made while debugging and improving the following-rates / alpha learning system.

---
### 1. Fix: phase 2 encoding bug (old value-based models are contaminated)

**The bug:** When comparing "pick" vs "stay" during the pick phase, the value of staying was looked up using the wrong state representation — the move-phase version of the state rather than the pick-phase version. Pick actions were evaluated correctly. So every greedy pick decision was based on a skewed comparison: the value of picking was correct, but the value of staying was read from the critic as if the agent were still in the move phase. This biased the policy toward or away from staying in a way that does not reflect what the critic actually learned.

**The fix:** The state passed to the policy during pick phase now has the pick-phase flag set, so STAY's value is looked up with the correct state representation.


---

### 2. Change: new definition of alpha (advantage over STAY)

**Old:** alpha was the one-step return of the selected action for each observer — `α_i = r_i(a) + γ·V_i(s')`

**New:** alpha is that return *minus* the one-step return of STAY — `α_i = [r_i(a) + γ·V_i(s'_a)] − [r_i(STAY) + γ·V_i(s'_STAY)]`

This measures the actor's marginal contribution to each observer relative to doing nothing. The STAY baseline removes shared background value drift, making alpha a cleaner signal of whether the actor's move helped or hurt. Applies to both the CPU and GPU trainer code paths.

---

### 3. Feature: `warmup_steps` — skip weight updates during alpha/beta warm-up

New config field `train.warmup_steps` (default `0`, requires `algorithm.name=actor_critic`).

During warmup, actor and critic gradient updates are skipped, but all forward passes, alpha estimates, beta updates, and following-rate reallocations still run normally. This lets alpha/beta reach a reasonable steady state before model weights are touched — useful when resuming from a pretrained checkpoint.

---

### 4. Feature: detailed alpha state logging (`alpha_states.jsonl`)

New config field `logging.alpha_state_log_freq` (default `0`, disabled). When set to `k`, every k-th step writes a JSON record to `<run_dir>/alpha_states.jsonl` with the current state (agent/task positions), where the actor lands after the selected action, which observers are teammates of the actor, and the full per-observer decomposition: `reward_diffs`, `value_diffs`, `gamma_value_diffs`, and `alpha_estimates`.

---

### 5. Fix: viz checkpoint loading and encoding

- `viz/__main__.py` now loads actor networks from actor-critic checkpoints and uses actor-network argmax for the `learned` policy, matching trainer inference.
- Switched from `encode_batch_for_actions` to `encode_all_agents_for_actions`, which correctly includes the actor's own position channel — the old path produced critic inputs that didn't match training-time encodings.
- Checkpoint loading now handles both the legacy `networks` key and the new `critics` key.
